### PR TITLE
Conversation with branching nodes working now.

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,5 +290,6 @@ applications:
 * Open *Manage* tab and click *Launch tool*
 * Pause for the discussion on Conversation service. Have fun with creating new foods and kinds of responses
 
-## Additional exercises
-* Current implementation doesn't support branching dialogs since it doesn't track the state of the conversation. Consult the documentation and build more complex bot: https://www.ibm.com/watson/developercloud/conversation/api/v1/
+## New Release
+* Before: Current implementation doesn't support branching dialogs since it doesn't track the state of the conversation. Consult the documentation and build more complex bot: https://www.ibm.com/watson/developercloud/conversation/api/v1/
+* Now: Conversation flow works perfectly!

--- a/README.md
+++ b/README.md
@@ -292,4 +292,4 @@ applications:
 
 ## New Release
 * Before: Current implementation doesn't support branching dialogs since it doesn't track the state of the conversation. Consult the documentation and build more complex bot: https://www.ibm.com/watson/developercloud/conversation/api/v1/
-* Now: Conversation flow works perfectly!
+* Now: Conversation flow works perfectly with branching dialogs!

--- a/chat-bot-ui/src/components/MessageForm.vue
+++ b/chat-bot-ui/src/components/MessageForm.vue
@@ -8,6 +8,8 @@
 <script>
 import axios from 'axios'
 
+var context = "" 
+
 export default {
   data () {
     return {
@@ -23,10 +25,12 @@ export default {
       this.$emit('messageSent', {
         author: 'me',
         text: this.text,
+        context: context,
         timestamp: new Date().toLocaleString()
       })
 
-      axios.post(process.env.API_URL + '/ask', { question: this.text }).then((resp) => {
+      axios.post(process.env.API_URL + '/ask', { question: this.text, context: context }).then((resp) => {
+      context = resp.data.context;
         this.$emit('messageSent', {
           author: 'bot',
           text: resp.data.answer,


### PR DESCRIPTION
Before, when we sent some message and tried to continue the same conversation, the API responded with the first parent's only nodes, not the child's nodes. With this change, we can take advantage of all the conversation nodes.